### PR TITLE
add helper function for printing instruction traces / getting path length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod hooks;
 pub mod simple_memory;
 pub mod solver_utils;
 mod state;
+pub use state::get_path_length;
 mod varmap;
 pub mod watchpoints;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -2078,11 +2078,11 @@ where
                     }
                     // add terminator, but only if we did not leave bb early bc of function call.
                     if !broke_early {
-                        path_str.push_str(&format!("{:?}\n", location.bb.term));
+                        path_str.push_str(&format!("{}\n", location.bb.term));
                     }
                 }
                 BBInstrIndex::Terminator => {
-                    path_str.push_str(&format!("{:?}\n", location.bb.term));
+                    path_str.push_str(&format!("{}\n", location.bb.term));
                 }
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2031,6 +2031,63 @@ where
         }
         path_str
     }
+    
+    /// returns a `String` containing a formatted view of the full path which led
+    /// to this point, in terms of LLVM IR instructions. If the Path includes any
+    /// hooked functions, the instructions which might be contained within those
+    /// functions are not included.
+    pub fn pretty_path_llvm_instructions(&self) -> String {
+        // to correctly print an instruction trace in the presence of function calls,
+        // we need to know which calls divert control flow to another basic block. This
+        // can be determined by finding all basic blocks in the path which do not
+        // begin at instruction 0.
+        let mut reenter_set = HashSet::new(); //Store (bb_name, instr_idx) of all calls that leave bb
+        for path_entry in self.get_path().iter() {
+            match path_entry.0.instr {
+                BBInstrIndex::Instr(idx) => {
+                    if idx != 0 {
+                        reenter_set.insert((path_entry.0.bb.name.clone(), idx - 1));
+                    }
+                }
+                BBInstrIndex::Terminator => {
+                    let num_instrs = path_entry.0.bb.instrs.len();
+                    if num_instrs > 0 {
+                        // tail call!
+                        reenter_set.insert((path_entry.0.bb.name.clone(), num_instrs - 1));
+                    }
+                }
+            }
+        }
+        let mut path_str = String::new();
+        for path_entry in self.get_path().iter() {
+            let location = &path_entry.0;
+            match location.instr {
+                BBInstrIndex::Instr(idx) => {
+                    let mut broke_early = false;
+                    for instr in location.bb.instrs.iter().skip(idx) {
+                        path_str.push_str(&format!("{}\n", instr));
+                        match instr {
+                            llvm_ir::instruction::Instruction::Call(_) => {
+                                if reenter_set.contains(&(location.bb.name.clone(), idx)) {
+                                    broke_early = true;
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    // add terminator, but only if we did not leave bb early bc of function call.
+                    if !broke_early {
+                        path_str.push_str(&format!("{:?}\n", location.bb.term));
+                    }
+                }
+                BBInstrIndex::Terminator => {
+                    path_str.push_str(&format!("{:?}\n", location.bb.term));
+                }
+            }
+        }
+        path_str
+    }
 
     /// returns a `String` containing a formatted view of the full path which led
     /// to this point, in terms of source locations
@@ -2218,6 +2275,36 @@ impl PathDumpType {
         }
     }
 }
+
+/// Returns the number of LLVM instructions in a passed path.
+/// The returned value is only accurate if the path under
+/// analysis does not include a panic, exception, exit,
+/// or any hooked calls (such as inline assembly).
+// A path is represented as a vector of `PathEntry`s, and
+// each `PathEntry` describes a sequential set of instructions in a basic block,
+// not necessarily starting at the beginning of that basic block.
+// When a `PathEntry` does not start at the beginning of a basic block, that means
+// we have returned to the basic block after a function call within that block.
+pub fn get_path_length<'p>(path: &Vec<PathEntry<'p>>) -> usize {
+    path.iter().fold(0, |acc, entry| {
+        let location = &entry.0;
+        let entry_len = match location.instr {
+            BBInstrIndex::Instr(0) => location.bb.instrs.len() + 1, // +1 for terminator
+            BBInstrIndex::Instr(_) => 0,                            // already counted
+            BBInstrIndex::Terminator => {
+                // Path with only a terminator: 1 instruction, not counted yet.
+                // Tail calls: we already counted the terminator, this is a duplicate bb
+                if location.bb.instrs.len() == 0 {
+                    1
+                } else {
+                    0
+                }
+            }
+        };
+        acc + entry_len
+    })
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/tests/call_tests.rs
+++ b/tests/call_tests.rs
@@ -248,24 +248,19 @@ fn test_pretty_path_llvm_instructions() {
     let proj = get_project();
     let mut em: ExecutionManager<haybale::backend::DefaultBackend> =
         symex_function(funcname, &proj, Config::default(), None).unwrap();
-    loop {
-        match em.next() {
-            Some(_) => {}
-            None => break,
-        }
-        let state = em.state();
-        let path = state.get_path();
-        let len = haybale::get_path_length(path);
-        let instrs = state.pretty_path_llvm_instructions();
-        let actual_instrs = "%3 = add i32 %1, i32 %0\n\
-                             %4 = tail call @simple_caller(i32 %3)\n\
-                             %2 = tail call @simple_callee(i32 %0, i32 3)\n\
-                             %3 = sub i32 %0, i32 %1\n\
-                             ret i32 %3\n\
-                             ret i32 %2\n\
-                             ret i32 %4\n";
+    em.next().expect("Expected a path").unwrap();
+    let state = em.state();
+    let len = state.get_path_length();
+    let instrs = state.pretty_path_llvm_instructions();
+    let actual_instrs = "%3 = add i32 %1, i32 %0\n\
+                         %4 = tail call @simple_caller(i32 %3)\n\
+                         %2 = tail call @simple_callee(i32 %0, i32 3)\n\
+                         %3 = sub i32 %0, i32 %1\n\
+                         ret i32 %3\n\
+                         ret i32 %2\n\
+                         ret i32 %4\n";
 
-        assert_eq!(len, instrs.matches("\n").count());
-        assert_eq!(instrs, actual_instrs,);
-    }
+    assert_eq!(len, instrs.matches("\n").count());
+    assert_eq!(instrs, actual_instrs,);
+    assert!(em.next().is_none(), "Expected only one path");
 }

--- a/tests/call_tests.rs
+++ b/tests/call_tests.rs
@@ -240,3 +240,30 @@ fn mutually_recursive_functions() {
     assert_eq!(args.len(), 1);
     //assert_eq!(args[0], SolutionValue::I32(3))
 }
+
+#[test]
+fn test_pretty_path_llvm_instructions() {
+    let funcname = "nested_caller";
+    init_logging();
+    let proj = get_project();
+    let mut em: ExecutionManager<haybale::backend::DefaultBackend> =
+        symex_function(funcname, &proj, Config::default(), None).unwrap();
+    loop {
+        match em.next() {
+            Some(res) => match res {
+                Ok(_) => {
+                    println!("next() worked");
+                }
+                Err(_) => {}
+            },
+            None => break,
+        }
+        let state = em.state();
+        let path = state.get_path();
+        let len = haybale::get_path_length(path);
+        assert_eq!(
+            len,
+            state.pretty_path_llvm_instructions().matches("\n").count() - 1
+        );
+    }
+}

--- a/tests/call_tests.rs
+++ b/tests/call_tests.rs
@@ -250,20 +250,22 @@ fn test_pretty_path_llvm_instructions() {
         symex_function(funcname, &proj, Config::default(), None).unwrap();
     loop {
         match em.next() {
-            Some(res) => match res {
-                Ok(_) => {
-                    println!("next() worked");
-                }
-                Err(_) => {}
-            },
+            Some(_) => {}
             None => break,
         }
         let state = em.state();
         let path = state.get_path();
         let len = haybale::get_path_length(path);
-        assert_eq!(
-            len,
-            state.pretty_path_llvm_instructions().matches("\n").count() - 1
-        );
+        let instrs = state.pretty_path_llvm_instructions();
+        let actual_instrs = "%3 = add i32 %1, i32 %0\n\
+                             %4 = tail call @simple_caller(i32 %3)\n\
+                             %2 = tail call @simple_callee(i32 %0, i32 3)\n\
+                             %3 = sub i32 %0, i32 %1\n\
+                             ret i32 %3\n\
+                             ret i32 %2\n\
+                             ret i32 %4\n";
+
+        assert_eq!(len, instrs.matches("\n").count());
+        assert_eq!(instrs, actual_instrs,);
     }
 }


### PR DESCRIPTION
This PR adds a helper function for printing an LLVM IR instruction trace for a `State`, as well as a helper function for getting the number of LLVM IR instructions in a given path. Both functions only provide accurate output if no hooked functions are contained in the `Path` being analyzed (per discussion in #5 ).

For `pretty_path_llvm_instructions()`, I ended up just using a lookahead cache approach to see if a given `Call` leaves the current basic block. I played for awhile with trying to use `resolve_function(call)` to see if it returns `NoHookActive`, but `resolve_function()` mutates the `State` under analysis, which seems clearly undesirable here. And pulling out the minimum logic from within `resolve_function()` necessary was actually a lot of repeated code that would likely fall out of data if updates were made to `resolve_function()` in the future.

This PR also adds a test of both functions, which simply checks that the number of instructions in the pretty print is equal to the number the returned length. Unfortunately, I consistently find that there is one more instruction in the pretty path than the length function reports there should be -- if you see any logic error by me that could lead to this, please let me know.

I understand these functions may be of limited use for most users, who might often have hooked functions in their path -- I am not sure if you want to go further than I did to make these functions only usable alongside a particular configuration, for example.

I struggled to get `cargo fmt` to work correctly with your modified rustfmt.toml. `cargo fmt` fails, saying a nightly toolchain is required. `cargo +nightly fmt` leads to tons of changes in files I did not touch, so it seems to not be what you used. So you may want to add a formatting commit to this PR.