### PR TITLE
ignore llvm.experimental.noalias.scope.decl intrinsic

### DIFF
--- a/src/symex.rs
+++ b/src/symex.rs
@@ -1713,6 +1713,7 @@ where
                         || funcname.starts_with("llvm.strip.invariant")
                         || funcname.starts_with("llvm.dbg")
                         || funcname.starts_with("llvm.expect")
+                        || funcname.starts_with("llvm.experimental.noalias.scope.decl")
                     {
                         // these are all safe to ignore
                         Ok(ResolvedFunction::HookActive {


### PR DESCRIPTION
This intrinsic seems to show up a lot in Rust-produced LLVM-IR lately. It is described here: https://llvm.org/docs/LangRef.html#llvm-experimental-noalias-scope-decl-intrinsic . I have not put a ton of thought into whether this is actually safe to ignore, but at a glance I figure it seems sort of similar to the lifetime intrinsic which we already ignore.